### PR TITLE
Delegate clean tasks to external dependencies

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -57,7 +57,7 @@ build/defaultDb.h: $(wildcard golpe.yaml src/apps/*/golpe.yaml)
 clean:
 	rm -f $(BIN) src/*.{o,d} src/apps/*/*.{o,d}
 	rm -rf build/
-	rm -f golpe/external/uWebSockets/src/{*.o,libuWS.a,libuWS.so}
+	$(foreach dir, config json lmdbxx PEGTL uWebSockets, $(MAKE) -C golpe/external/$(dir) clean;)
 
 update-submodules:
 	git submodule update --init

--- a/rules.mk
+++ b/rules.mk
@@ -55,7 +55,7 @@ build/defaultDb.h: $(wildcard golpe.yaml src/apps/*/golpe.yaml)
 	PERL5LIB=golpe/vendor/ golpe/external/rasgueadb/rasgueadb-generate golpe.yaml build
 
 clean:
-	rm -f $(BIN) src/*.o src/*.d src/apps/*/*.o src/apps/*/*.d
+	rm -f $(BIN) src/*.{o,d} src/apps/*/*.{o,d}
 	rm -rf build/
 	rm -f golpe/external/uWebSockets/src/{*.o,libuWS.a,libuWS.so}
 


### PR DESCRIPTION
Previously `libuWS.a` and `libuWS.so` and a few other leftovers from other external dependencies weren't cleaned.
