### PR TITLE
add support for configuration options via cli (--set)

### DIFF
--- a/config.cpp.tt
+++ b/config.cpp.tt
@@ -1,4 +1,6 @@
 #include <mutex>
+#include <algorithm>
+#include <cctype>
 
 #include "golpe.h"
 
@@ -7,6 +9,58 @@
 
 std::atomic<ConfigValues*> currentCfg;
 std::mutex currentCfgModificationMutex;
+std::vector<ConfigOverride> cliOverrides;
+
+
+static std::string normalizeConfigKey(std::string key) {
+    size_t pos = 0;
+
+    while ((pos = key.find("__", pos)) != std::string::npos) {
+        key.replace(pos, 2, ".");
+        pos += 1;
+    }
+
+    return key;
+}
+
+
+static uint64_t parseUint64Override(const std::string &key, const std::string &rawValue) {
+    if (rawValue.empty() || rawValue[0] == '-') {
+        throw herr("invalid uint64 value for --set key '", key, "': '", rawValue, "'");
+    }
+
+    size_t parsedChars = 0;
+    unsigned long long parsedValue = 0;
+
+    try {
+        parsedValue = std::stoull(rawValue, &parsedChars, 10);
+    } catch (std::exception &) {
+        throw herr("invalid uint64 value for --set key '", key, "': '", rawValue, "'");
+    }
+
+    if (parsedChars != rawValue.size()) {
+        throw herr("invalid uint64 value for --set key '", key, "': '", rawValue, "'");
+    }
+
+    return static_cast<uint64_t>(parsedValue);
+}
+
+
+static bool parseBoolOverride(const std::string &key, std::string rawValue) {
+    std::transform(rawValue.begin(), rawValue.end(), rawValue.begin(), [](unsigned char c){
+        return static_cast<char>(std::tolower(c));
+    });
+
+    if (rawValue == "1" || rawValue == "true" || rawValue == "yes" || rawValue == "on") {
+        return true;
+    }
+
+    if (rawValue == "0" || rawValue == "false" || rawValue == "no" || rawValue == "off") {
+        return false;
+    }
+
+    throw herr("invalid bool value for --set key '", key, "': '", rawValue, "' (use true/false/1/0/yes/no/on/off)");
+}
 
 
 tao::config::value loadRawTaoConfig(const std::string &configFile) {
@@ -23,11 +77,22 @@ tao::config::value loadRawTaoConfig(const std::string &configFile) {
 
 
 void loadConfig(const std::string &configFile) {
+    loadConfig(configFile, {});
+}
+
+
+void loadConfig(const std::string &configFile, const std::vector<ConfigOverride> &overrides) {
     std::lock_guard<std::mutex> guard(currentCfgModificationMutex);
 
     LI << "CONFIG: Loading config from file: " << configFile;
 
     tao::config::value configJson = loadRawTaoConfig(configFile);
+
+    if (!overrides.empty()) {
+        cliOverrides = overrides;
+    }
+
+    const std::vector<ConfigOverride> &effectiveOverrides = cliOverrides;
 
     std::unique_ptr<ConfigValues> tmpCfg = std::make_unique<ConfigValues>(currentCfg.load() ? currentCfg.load()->version() + 1 : 1);
 
@@ -58,6 +123,33 @@ void loadConfig(const std::string &configFile) {
         [% END %]
     } while(0);
     [% END %]
+
+    if (!effectiveOverrides.empty()) {
+        for (const auto &[rawKey, rawValue] : effectiveOverrides) {
+            const std::string key = normalizeConfigKey(rawKey);
+            bool matched = false;
+
+            [% FOREACH c IN config %]
+            if (!matched && key == normalizeConfigKey("[% c.name %]")) {
+                [% IF c.type == 'uint64' %]
+                    tmpCfg->[% c.nameCpp %] = parseUint64Override(rawKey, rawValue);
+                [% ELSIF c.type == 'string' %]
+                    tmpCfg->[% c.nameCpp %] = rawValue;
+                [% ELSIF c.type == 'bool' %]
+                    tmpCfg->[% c.nameCpp %] = parseBoolOverride(rawKey, rawValue);
+                [% ELSE %]
+                    #error "unknown type [% c.type %]"
+                [% END %]
+
+                matched = true;
+            }
+            [% END %]
+
+            if (!matched) {
+                throw herr("unknown config key for --set override: ", rawKey);
+            }
+        }
+    }
 
     // Log config changes and check for non-reloadable changes
 

--- a/config.h.tt
+++ b/config.h.tt
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <atomic>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <tao/config/value.hpp>
 
@@ -20,8 +23,11 @@ struct ConfigValues {
 
 };
 
+using ConfigOverride = std::pair<std::string, std::string>;
+
 tao::config::value loadRawTaoConfig(const std::string &configFile);
 void loadConfig(const std::string &configFile);
+void loadConfig(const std::string &configFile, const std::vector<ConfigOverride> &overrides);
 
 extern std::atomic<ConfigValues*> currentCfg;
 

--- a/main.cpp.tt
+++ b/main.cpp.tt
@@ -6,6 +6,7 @@
 #include <sys/types.h>
 
 #include <iostream>
+#include <vector>
 
 #include <hoytech/error.h>
 #include <docopt.h>
@@ -18,10 +19,11 @@
 
 static const char USAGE[] =
 R"(
-    Usage: [% golpe.appName %] [% IF golpe.features.config %][--config=<config>][% END -%] [--verbosity=<level>] <command> [<args>...]
+        Usage: [% golpe.appName %] [% IF golpe.features.config %][--config=<config>] [--set=<entry>]...[% END -%] [--verbosity=<level>] <command> [<args>...]
 
     Options:
       [% IF golpe.features.config %]--config=<config>      Config file (default $ENV{[% golpe.appName FILTER upper %]_CONFIG} || "/etc/[% golpe.appName %].conf" || "./[% golpe.appName %].conf")[% END %]
+      [% IF golpe.features.config %]--set=<entry>          Override config value via key=value, Alternate form: --set <key> <value>[% END %]
       --verbosity=<level>    Logging level: ERROR (only errors), WARN (errors+warnings), INFO (default), 1 (debug)
       -h --help              Show this screen.
       --version              Show version.
@@ -46,6 +48,99 @@ R"(
 
 [% IF golpe.features.config %]
 std::string configFile;
+
+
+struct ParsedSetCliArgs {
+    std::vector<std::string> docoptArgs;
+    std::vector<ConfigOverride> overrides;
+};
+
+
+static bool isOptionToken(const std::string &arg) {
+    return !arg.empty() && arg[0] == '-';
+}
+
+
+static void parseSetAssignment(const std::string &entry, std::vector<ConfigOverride> &overrides) {
+    size_t pos = entry.find('=');
+
+    if (pos == std::string::npos || pos == 0) {
+        throw herr("invalid --set assignment (expected key=value): ", entry);
+    }
+
+    if (entry[0] == '-') {
+        throw herr("invalid --set key: ", entry.substr(0, pos));
+    }
+
+    overrides.emplace_back(entry.substr(0, pos), entry.substr(pos + 1));
+}
+
+
+static ParsedSetCliArgs parseSetCliArgs(int argc, char **argv) {
+    ParsedSetCliArgs parsed;
+    parsed.docoptArgs.reserve(argc > 0 ? static_cast<size_t>(argc - 1) : 0);
+
+    bool parsingGlobalOptions = true;
+
+    for (int i = 1; i < argc; i++) {
+        std::string arg = argv[i];
+
+        if (parsingGlobalOptions && arg == "--set") {
+            if (i + 1 >= argc) {
+                throw herr("missing value after --set");
+            }
+
+            std::string entryOrKey = argv[++i];
+
+            if (entryOrKey.find('=') != std::string::npos) {
+                parseSetAssignment(entryOrKey, parsed.overrides);
+            } else {
+                if (entryOrKey.empty() || entryOrKey[0] == '-') {
+                    throw herr("invalid --set key: ", entryOrKey);
+                }
+
+                if (i + 1 >= argc) {
+                    throw herr("missing value for --set key: ", entryOrKey);
+                }
+
+                parsed.overrides.emplace_back(entryOrKey, argv[++i]);
+            }
+
+            continue;
+        }
+
+        if (parsingGlobalOptions && arg.rfind("--set=", 0) == 0) {
+            parseSetAssignment(arg.substr(strlen("--set=")), parsed.overrides);
+            continue;
+        }
+
+        parsed.docoptArgs.push_back(arg);
+
+        if (!parsingGlobalOptions) {
+            continue;
+        }
+
+        if (arg == "--") {
+            parsingGlobalOptions = false;
+            continue;
+        }
+
+        if (arg == "--verbosity"[% IF golpe.features.config %] || arg == "--config"[% END %]) {
+            if (i + 1 >= argc) {
+                throw herr("missing value after ", arg);
+            }
+
+            parsed.docoptArgs.push_back(argv[++i]);
+            continue;
+        }
+
+        if (!isOptionToken(arg)) {
+            parsingGlobalOptions = false;
+        }
+    }
+
+    return parsed;
+}
 [% END %]
 
 [% IF golpe.features.db %]
@@ -70,7 +165,12 @@ void run(int argc, char **argv) {
     onPreStartup(argc, argv);
     [% END %]
 
+    [% IF golpe.features.config %]
+    auto parsedSetCli = parseSetCliArgs(argc, argv);
+    std::map<std::string, docopt::value> args = docopt::docopt(USAGE, parsedSetCli.docoptArgs, true, "[% golpe.appName %] " APP_GIT_VERSION, true);
+    [% ELSE %]
     std::map<std::string, docopt::value> args = docopt::docopt(USAGE, { argv + 1, argv + argc }, true, "[% golpe.appName %] " APP_GIT_VERSION, true);
+    [% END %]
 
     loguru::g_stderr_verbosity = 0;
     loguru::g_preamble_file = false;
@@ -96,7 +196,7 @@ void run(int argc, char **argv) {
         throw hoytech::error("please specify config file");
     }
 
-    loadConfig(configFile);
+    loadConfig(configFile, parsedSetCli.overrides);
     [% END %]
 
     std::string command = args["<command>"].asString();


### PR DESCRIPTION
this pr will enable configure options directly via the cli.
for example, somethign like `--set option=value` will work. 
you can repeat `--set` as many times as you want to configure different options.
options configured via the cli take precedence over the config file and are also unaffected by hot-reload.